### PR TITLE
Added a mechanism to stop collecting rpc methods from base classes.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,8 +58,19 @@ Example usage:
         def sayMooh(self, cow):  # noqa
             return self.gen_name(cow.name)
 
+        @rpc(Cow, _returns=Unicode)
+        def noInheritance(self, cow):  # noqa
+            # This method won't be inherited because we set the 
+            # collect_base_methods = False in the overridden delegate
+            return self.gen_name(cow.name)
+
 
     class CowDelegateOverridden(CowDelegate):
+
+        # With this property we don't expose inherited methods from the base
+        # class
+        collect_base_methods = False
+
         @rpc(Cow, _returns=Unicode)
         def sayMooh(self, cow):  # noqa
             # call the super and add a 'overridden' string

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 
 setup(

--- a/spynedelegate/meta.py
+++ b/spynedelegate/meta.py
@@ -82,8 +82,9 @@ class DelegateMetaClass(type):
         spyne_attrs = {}
 
         # collect spyne methods from base classes.
-        for base in reversed(bases):
-            spyne_attrs.update(getattr(base, '_spyne_cls_dict', {}))
+        if attrs.get('collect_base_methods', True):
+            for base in reversed(bases):
+                spyne_attrs.update(getattr(base, '_spyne_cls_dict', {}))
 
         # collect spyne methods in the delegate class.
         for k, v in attrs.items():

--- a/tests/application.py
+++ b/tests/application.py
@@ -48,8 +48,19 @@ class CowDelegate(DelegateBase):
     def sayMooh(self, cow):  # noqa
         return self.gen_name(cow.name)
 
+    @rpc(Cow, _returns=Unicode)
+    def noInheritance(self, cow):  # noqa
+        # This method won't be inherited because we set the 
+        # collect_base_methods = False in the overridden delegate
+        return self.gen_name(cow.name)
+
 
 class CowDelegateOverridden(CowDelegate):
+
+    # With this property we don't expose inherited methods from the base
+    # class
+    collect_base_methods = False
+
     @rpc(Cow, _returns=Unicode)
     def sayMooh(self, cow):  # noqa
         # call the super and add a 'overridden' string

--- a/tests/test_with_suds.py
+++ b/tests/test_with_suds.py
@@ -38,6 +38,10 @@ class SudsClientTest(SpyneServerTestCase):
         self.assertTrue('sayMooh' in self.methods)
         self.assertTrue('thisStillWorks' in self.methods)
 
+        # the function noInheritance should not be there as we set
+        # 'collect_base_methods' to False
+        self.assertFalse('noInheritance' in self.methods)
+
         chicken = self.client.factory.create("ns0:Chicken")
         chicken.name = "toktok"
         chicken_results = self.client.service.multiplyChickens(chicken)


### PR DESCRIPTION
do this::

    class CowDelegate(DelegateBase):
        @property
        def method_request_string(self):
            # you can access the context with self.ctx
            return self.ctx.method_request_string

        def gen_name(self, name):
            # and you can use self as well
            return "%s -> %s" % (self.method_request_string, name)

        @rpc(Cow, _returns=Unicode)
        def sayMooh(self, cow):  # noqa
            return self.gen_name(cow.name)

    class CowDelegateOverridden(CowDelegate):

        collect_base_methods = False

        @rpc(Cow, _returns=Unicode)
        def sayMooh(self, cow):  # noqa
            # call the super and add a 'overridden' string
            result = super(CowDelegateOverridden, self).sayMooh(cow)
            return "%s overridden" % result

        @rpc(Unicode, _returns=Unicode)
        def generateName(self, name):
            # shows that we call a regular supermethod
            return super(CowDelegateOverridden, self).gen_name(name)