### PR TITLE
Bug/exception namespace flip flop bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 
 setup(


### PR DESCRIPTION
This patch implements a way to solve a very ugly and weird problem.

You do have to configure it yourself, it is not applied automatically.
When you have the Fault namespace flipflop problem, you have to define a
property on your service class::

    class CleanWashingSoap11(ExtensibleServiceBase):
        delegate = CleanWashingDelegate
        _FORCE_EXCEPTION_NAMESPACE = 'clean.washing.justdoit'

Doing that will make sure that any _throw attributes on your rpc decorator
will be fixed so that they all have the same namespace.